### PR TITLE
remove contact as name; parse subjects and names

### DIFF
--- a/mods-maps/mods-mapping-all.xml
+++ b/mods-maps/mods-mapping-all.xml
@@ -93,12 +93,6 @@
             <roleTerm type="text">Interviewee</roleTerm>
         </role>
     </name>
-    <name type="personal">
-        <namePart><?cdm-element-name contact?></namePart>
-        <role>
-            <roleTerm type="text">Curator</roleTerm>
-        </role>
-    </name>
     <name type="corporate">
         <namePart><?cdm-element-name contributing_institution?></namePart>
         <role>


### PR DESCRIPTION
- remove mapping of contact to /mods/name/namePart
- add parsing of semicolon delimited values for /mods/subject/ children temporal, geographic, topic and /mods/name/namePart