### PR TITLE
updated for module revision respecting contentdm page sequence

### DIFF
--- a/mods-processes/cdm-mods-final-level-to-books.xsl
+++ b/mods-processes/cdm-mods-final-level-to-books.xsl
@@ -39,7 +39,7 @@
                      so no recursion is needed to list the children -->
                 <node id="{$node-id}" cmodel="{$cmodel}">
                     <xsl:for-each
-                    select="/mods:modsCollection/mods:mods[mods:relatedItem[@otherType = 'isChildOf']/mods:identifier[. = $node-id]]">
+                    select="/mods:modsCollection/mods:mods[mods:relatedItem[@otherType = 'isChildOf']/mods:identifier[not(@type)][. = $node-id]]">
                         <xsl:variable name="node-id" select="mods:identifier[@type = 'islandora']"/>
                         <xsl:variable name="cmodel" select="mods:relatedItem[@otherType = 'islandoraCModel']/mods:identifier"/>
                         <node id="{$node-id}" cmodel="{$cmodel}"/>
@@ -124,7 +124,8 @@
          book page.
     -->    <xsl:template match="mods:mods[mods:relatedItem[@otherType = 'isChildOf']][matches(mods:relatedItem[@otherType = 'islandoraCModel']/mods:identifier,'image')]/mods:relatedItem[@otherType = 'isChildOf']" exclude-result-prefixes="#all">
         <xsl:variable name="identifier" select="parent::mods:mods/mods:identifier[@type = 'islandora']"/>
-        <xsl:variable name="book-identifier" select="normalize-space(mods:identifier)"/>
+        <!-- remember the new identifier[@type = 'sequenceNo'] is at this level too now, so use not(@type) -->
+        <xsl:variable name="book-identifier" select="normalize-space(mods:identifier[not(@type)])"/>
         <xsl:choose>
             <xsl:when test="$tree//node[@id = $identifier][not(parent::node/node[@cmodel = 'islandora:collectionCModel'])][not(parent::node/node[not(matches(@cmodel,'image'))])]">
                 <relatedItem xmlns="http://www.loc.gov/mods/v3" otherType="isPageOf" otherTypeAuth="dgi">

--- a/mods-processes/cdm-mods-final-level-to-newspapers.xsl
+++ b/mods-processes/cdm-mods-final-level-to-newspapers.xsl
@@ -39,7 +39,7 @@
                      so no recursion is needed to list the children -->
                 <node id="{$node-id}" cmodel="{$cmodel}">
                     <xsl:for-each
-                    select="/mods:modsCollection/mods:mods[mods:relatedItem[@otherType = 'isChildOf']/mods:identifier[. = $node-id]]">
+                        select="/mods:modsCollection/mods:mods[mods:relatedItem[@otherType = 'isChildOf']/mods:identifier[not(@type)][. = $node-id]]">
                         <xsl:variable name="node-id" select="mods:identifier[@type = 'islandora']"/>
                         <xsl:variable name="cmodel" select="mods:relatedItem[@otherType = 'islandoraCModel']/mods:identifier"/>
                         <node id="{$node-id}" cmodel="{$cmodel}"/>
@@ -124,7 +124,8 @@
     -->
     <xsl:template match="mods:mods[mods:relatedItem[@otherType = 'isChildOf']][matches(mods:relatedItem[@otherType = 'islandoraCModel']/mods:identifier,'image')]/mods:relatedItem[@otherType = 'isChildOf']" exclude-result-prefixes="#all">
         <xsl:variable name="identifier" select="parent::mods:mods/mods:identifier[@type = 'islandora']"/>
-        <xsl:variable name="newspaper-identifier" select="normalize-space(mods:identifier)"/>
+        <!-- remember the new identifier[@type = 'sequenceNo'] is at this level too now, so use not(@type) -->
+        <xsl:variable name="newspaper-identifier" select="normalize-space(mods:identifier[not(@type)])"/>
         <xsl:choose>
             <xsl:when test="$tree//node[@id = $identifier][not(parent::node/node[@cmodel = 'islandora:collectionCModel'])][not(parent::node/node[not(matches(@cmodel,'image'))])]">
                 <relatedItem xmlns="http://www.loc.gov/mods/v3" otherType="isPageOf" otherTypeAuth="dgi">

--- a/mods-processes/postprocess-to-books.pl
+++ b/mods-processes/postprocess-to-books.pl
@@ -14,8 +14,8 @@ foreach my $infile (@files)
     my $outfile = $infile;
     $outfile =~ s/^$inputdir/$outputdir/o;
 	
-	system("java -Xmx1000M -Xms1000M -cp C:\\Saxonica9.6\\saxon9pe.jar net.sf.saxon.Transform -t -o:_tmp.1 -s:$infile -xsl:hslc-mods-updates-template.xsl");
-	system("java -Xmx1000M -Xms1000M -cp C:\\Saxonica9.6\\saxon9pe.jar net.sf.saxon.Transform -t -o:$outfile -s:_tmp.1 -xsl:cdm-mods-final-level-to-books.xsl islandora-namespace=islandora");
+	system("java -Xmx1350M -Xms1350M -cp C:\\Saxonica9.6\\saxon9pe.jar net.sf.saxon.Transform -t -o:_tmp.1 -s:\"$infile\" -xsl:hslc-mods-updates-template.xsl");
+	system("java -Xmx1350M -Xms1350M -cp C:\\Saxonica9.6\\saxon9pe.jar net.sf.saxon.Transform -t -o:\"$outfile\" -s:_tmp.1 -xsl:cdm-mods-final-level-to-books.xsl islandora-namespace=papd");
 
 }
 

--- a/mods-processes/split-mods-files.pl
+++ b/mods-processes/split-mods-files.pl
@@ -1,0 +1,23 @@
+#! perl -w
+use strict;
+
+system("time /t"); # time begin
+
+my $inputdir = "in";
+my $outputdir = "out";
+
+my @files = glob("$inputdir/*.xml");
+
+
+foreach my $infile (@files)
+{
+    my $outfile = $infile;
+    $outfile =~ s/^$inputdir/$outputdir/o;
+	
+	system("java -Xmx1350M -Xms1350M -cp C:\\Saxonica9.6\\saxon9pe.jar net.sf.saxon.Transform -t -o:\"$outfile\" -s:\"$infile\" -xsl:split-mods-files.xsl objects-per-file=10000");
+
+}
+
+# unlink("_tmp.*");
+
+system("time /t"); # time end


### PR DESCRIPTION
The CONTENTdm module received an update to store the source data page sequence and ensure it is respected. The custom post processes to create books or newspapers require this update to address the correct parent identifier.